### PR TITLE
`cppm init-existing`

### DIFF
--- a/src/cppm.rs
+++ b/src/cppm.rs
@@ -350,6 +350,45 @@ impl Cppm {
     
         println!("Current version: {} - Latest version: cppm {}", current_version_str, latest)
     }
+
+    pub fn init_existing(name: String, repo: String, init_type: String) { // TODO: Add nice error messages
+        if init_type == "c" {
+            Cppm::spawn(name, "null".to_string(), "c");
+        } else {
+            Cppm::spawn(name, "null".to_string(), "c++");
+        }
+        Command::new("git")
+            .arg("init")
+            .output()
+            .expect("An error initializing Git - Make sure you have Git installed and try again!");
+        Command::new("git")
+            .arg("commit")
+            .arg("--allow-empty")
+            .arg("-m")
+            .arg("\"init\"")
+            .output()
+            .expect("An error occurred while trying to commit changes to Git - Make sure you have Git installed and try again");
+        Command::new("git")
+            .arg("branch")
+            .arg("-M")
+            .arg("main")
+            .output()
+            .expect("An error occured while trying to set the branch to main - Make sure you have Git installed and try again");
+        Command::new("git")
+            .arg("remote")
+            .arg("add")
+            .arg("origin")
+            .arg(repo)
+            .output()
+            .expect("An error occurred while trying to connect to the remote repository - Make sure the repository exists and try again");
+        Command::new("git")
+            .arg("push")
+            .arg("-u")
+            .arg("origin")
+            .arg("main")
+            .output()
+            .expect("An error occurred while trying to push changes to the repository - Make sure the repository exists and try again");
+    }
     
 
     /// Initializes a project in the current directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,12 @@ enum Command {
         #[clap(short)]
         c: bool,
     },
+    InitExisting {
+        name: String,
+        repo: String,
+        #[clap(short)]
+        c: bool,
+    },
     /// Initialize a cppm project in current directory
     Init {
         /// Generate C files instead of C++ files
@@ -136,6 +142,15 @@ fn main() {
                 env::set_current_dir(name.clone()).unwrap();
                 cppm::git_init();
                 //env::set_current_dir("../").unwrap();
+            }
+        }
+        Some(Command::InitExisting { name, repo, c }) => {
+            if c {
+                Cppm::init_existing(name.clone(), repo.clone(), "c".to_string());
+                println!("{}", "Project initialized successfully".bright_green());
+            } else {
+                Cppm::init_existing(name.clone(), repo.clone(), "c++".to_string());
+                println!("{}", "Project initialized successfully".bright_green());
             }
         }
         // warning: check

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ enum Command {
         #[clap(short)]
         c: bool,
     },
+    /// Initialize a new cppm project inside of an existing Git repository
     InitExisting {
         name: String,
         repo: String,


### PR DESCRIPTION
Just added the `init-existing` command, which lets you initialize a cppm project inside of an existing Git repository (It'll push the boilerplate code to the repo). The code is pretty ugly right now and requires some work (Error handling needs improvement) but I'll work on that later. :+1: 