### PR TITLE
default editor

### DIFF
--- a/src/cppm.rs
+++ b/src/cppm.rs
@@ -19,6 +19,9 @@ use crate::build::run;
 use serde_json::Value;
 use std::str;
 
+// Imports for default editor
+use toml::Value as TomlVal;
+
 #[derive(Serialize, Deserialize, Debug)]
 struct Config {
     name: String,

--- a/src/cppm.rs
+++ b/src/cppm.rs
@@ -255,6 +255,10 @@ impl Cppm {
 
     /// note: add aliases for known editors
     pub fn open(_project_name: String, editor: Option<String>) {
+        if !Path::new(&misc::configfile()).exists() {
+            println!("{}", "You have not created any projects yet!".red());
+            process::exit(0);
+        }
         let editor = match editor {
             Some(val) => val,
             None => {
@@ -263,10 +267,6 @@ impl Cppm {
                 value["editor"].to_string()
             }
         };
-        if !Path::new(&misc::configfile()).exists() {
-            println!("{}", "You have not created any projects yet!".red());
-            process::exit(0);
-        }
         if builder::subprocess(&editor, "").is_err() {
             println!(
                 "    {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,9 +116,9 @@ fn main() {
     match args.command {
         Some(Command::Open { name, editor }) => {
             if editor.is_some() {
-                Cppm::open(name, editor.unwrap());
+                Cppm::open(name, Some(editor));
             } else {
-                // note: do config stuff, get default ed if exists
+                Cppm::open(name, None);
             }
         }
         Some(Command::New { name, editor, c }) => {


### PR DESCRIPTION
I can't test this since I'm on Linux, but it should work. `cppm open` now takes the editor as an option, and if editor is `None` it'll try and parse the toml to find an editor. Then it should set the editor as either whatever the default is or whatever was passed.